### PR TITLE
adds `overscroll-behavior`

### DIFF
--- a/carouscroll.js
+++ b/carouscroll.js
@@ -27,6 +27,7 @@ class Carouscroll extends HTMLElement {
 	display: flex;
 	overflow-x: scroll;
 	overflow-y: hidden;
+ 	overscroll-behavior-x: contain;
 	scroll-snap-type: x mandatory;
 }
 ::slotted(*) {


### PR DESCRIPTION
cool component! while trying the demo I noticed my scroll gestures leaked out of the carousel element scrollport and thought i'd suggest fixing that. here it is =)

https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior