### PR TITLE
Update carouscroll.js to require buttons to be buttons

### DIFF
--- a/carouscroll.js
+++ b/carouscroll.js
@@ -77,17 +77,15 @@ class Carouscroll extends HTMLElement {
 	}
 
 	initializeButtons() {
-		this.nextButton = document.querySelector(`[${Carouscroll.attr.next}="${this.id}"]`);
-		this.prevButton = document.querySelector(`[${Carouscroll.attr.prev}="${this.id}"]`);
+		this.nextButton = document.querySelector(`button[${Carouscroll.attr.next}="${this.id}"]`);
+		this.prevButton = document.querySelector(`button[${Carouscroll.attr.prev}="${this.id}"]`);
 
 		this.prevButton?.addEventListener("click", e => {
 			this._buttonClick("previous");
-			e.preventDefault();
 		}, false);
 
 		this.nextButton?.addEventListener("click", e => {
 			this._buttonClick("next");
-			e.preventDefault();
 		}, false);
 	}
 


### PR DESCRIPTION
The Next, Previous buttons are functionally buttons (they "do something" they don't "go somewhere"), `data-carousel-next` and `data-carousel-previous` should only be supported on `<button>` elements, not links.

* Changed the selectors to include the `button` element.
* Removed `e.preventDefault();` from the click listeners as I believe there's no default behavior to prevent for a `<button>`.

If this PR is accepted, obviously the "Links instead of Buttons" example should be removed from demo.html.